### PR TITLE
update how the root path is first initialized

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -20,15 +20,14 @@ int main(int argc, char *argv[])
 
     auto root = AppSettings::GetRootPath();
     QDir dir(root);
-    if (root.isEmpty() || !dir.exists())
+    if (root.isEmpty() || !dir.setCurrent(root))
     {
 #if defined(Q_OS_LINUX)
         auto defaultPath = QDir::homePath() + "/.steam/steam/steamapps/common/Hypnospace Outlaw/data";
 #elif defined(Q_OS_WIN32)
         auto defaultPath = "C:/Program Files (x86)/Steam/steamapps/common/Hypnospace Outlaw/data";
 #endif
-        dir.setCurrent(defaultPath);
-        if (!dir.exists())
+        if (!dir.setCurrent(defaultPath))
         {
             QMessageBox::warning(nullptr, "Hypnospace Outlaw not found!", "Hypnospace Outlaw has not been found, please select the directory where the game is installed.");
             auto gamePath = QFileDialog::getExistingDirectory(nullptr, "Hypnospace Outlaw directory", QDir::homePath());
@@ -38,13 +37,19 @@ int main(int argc, char *argv[])
                 return 0;
             }
 
-            dir.setCurrent(gamePath);
+            gamePath += "/data";
 
-            if (dir.exists("data"))
+            if (!dir.exists(gamePath))
             {
-                dir.cd("data");
+                QMessageBox::information(nullptr, "Bye", "The selected folder does not contain a \"data\" folder. The application will now quit.");
+                return 0;
             }
 
+            if (!dir.setCurrent(gamePath))
+            {
+                QMessageBox::information(nullptr, "Bye", "Unable to open game folder. The application will now quit.");
+                return 0;
+            }
         }
 
         AppSettings::SetRootPath(dir.absolutePath());


### PR DESCRIPTION
Upon startup, PageBuilder checks for a settings.ini file containing the
path to a valid Hypnospace data directory. If that path happens to be
invalid, then any attempts to load a page which references an asset
will fail.

Steam users probably won't run into this problem because PageBuilder will
initialize itself to the Steam folder by default. Anyone using an
alternate distribution such as the GOG version or someone who keeps their
Steam library in a non-standard location will end up with PageBuilder's
current working directory being selected, but this is not a valid
location.

This update does three things:

 - In the case where no settings.ini file already exists, it will check
   whether a "data" folder is present before assuming that the current
   working directory is valid.
 - Make sure that the program's current directory is changed to the data
   folder selected.
 - Add additional error handling for cases where the user selects a folder
   which lacks a "data" subfolder or the program fails to access the
   selected folder.